### PR TITLE
Add live-verified AV-HS450 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,6 @@ See [HELP.md](./companion/HELP.md) and [LICENSE](./LICENSE)
 - Added the HS450 source-bus entries (ABST buses 16-18: `aux1s`, `pinP1s`, `pinP2s`) to the tally data struct and the `storeData` ABST handler.
 - 500ms keepalive polling enabled for the HS450 (same as the HS410).
 - Tally feedbacks enabled for the HS450. Auto transition *time* (`STIM`) is HS410_IF-only and is not offered for HS450 (set rates on the mixer; VS-R45/AUXP_IP has no STIM).
+- ATST auto-transition feedback (including DSK/PinP/FTB on/off) and ATLY physical-input PGM/PVW tally.
+- HS410 + multicast uses AUXP_IP SAUT (2-field; DSK=`02`) so PinP/DSK AUTO keep working with tally enabled ([#7](https://github.com/bitfocus/companion-module-panasonic-avhs/issues/7), [#14](https://github.com/bitfocus/companion-module-panasonic-avhs/issues/14)).
 - manifest `products` and `description` updated to include the AV-HS450.

--- a/README.md
+++ b/README.md
@@ -2,26 +2,24 @@
 
 See HELP.md and LICENSE
 
-**V1.0.2**
-
-- Bug-Fix for connection dropputs with AV-HS410
-- Fixed actions default not showing correctly
-- Added variables for AV-HS410 tally outputs and bus selections (only on AV-HS410)
-- Added Support for AV-UHS500
-- Yarn formated
-
-**V1.0.3**
-
-- Bug-Fix: Fixed variables not loading with the AV-HS410, when you had more than one network interface enabled
-- Some Error handling and stopped companion from crashing when updating the instance settings
-- Bug-Fix: Prevent companion from crashing when using more than one AV-HS410 video mixer
-
-**V1.0.4**
-
-- Added Tally feedback for AV-HS410
-- Changed error handling on Multicast
-- Added the option to disble Tally/Multicast on AV-HS410, if dissabled it will default to port 60040 (only needs one plugin then)
-
 **V2.0.0**
 
 - Conversion to Companion v3.x API
+
+**Unreleased — AV-HS450 support**
+
+- Added `AV-HS450` as a model option.
+- HS450 uses TCP port 60020 (same as the AV-HS410 multicast port) and pushes
+  tally/status via UDP multicast `224.0.0.200:60020`, so multicast tally support is enabled for the HS450 too.
+- Added `HS450_BUS`, `HS450_INPUTS`, `HS450_TARGETS`, `HS450_CUTTARGETS` to `constants.js`.
+  `HS450_INPUTS` covers all 32 XPT buttons (source ids 00-31), the 20 physical inputs
+  (16 SDI + 2x2 optional cards = source 50-69), and the internal signals
+  (CBAR, CBGD, Black, FMEM1-4, PGM, PVW, KEYOUT, CLN, MV1, MV2, ...).
+  Source ids 73-76 are labelled `FMEM1-4` (the HS450 frame-memory names; the HS410
+  spec labels them `Still1V`/`Still2V`/`Clip1V`/`Clip2V`).
+- `storeData` now uses the model-specific inputs list
+  (`self[model + '_INPUTS']`) so the HS450's 32-XPT range is resolved correctly (the HS410 only has 24 XPT).
+- Added the HS450 source-bus entries (ABST buses 16-18: `aux1s`, `pinP1s`, `pinP2s`) to the tally data struct and the `storeData` ABST handler.
+- 500ms keepalive polling enabled for the HS450 (same as the HS410).
+- `actions.time` (auto transition time control) and tally feedbacks enabled for the HS450.
+- manifest `products` and `description` updated to include the AV-HS450.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # companion-module-panasonic-avhs
 
-See HELP.md and LICENSE
+See [HELP.md](./companion/HELP.md) and [LICENSE](./LICENSE)
 
 **V2.0.0**
 

--- a/README.md
+++ b/README.md
@@ -21,5 +21,5 @@ See HELP.md and LICENSE
   (`self[model + '_INPUTS']`) so the HS450's 32-XPT range is resolved correctly (the HS410 only has 24 XPT).
 - Added the HS450 source-bus entries (ABST buses 16-18: `aux1s`, `pinP1s`, `pinP2s`) to the tally data struct and the `storeData` ABST handler.
 - 500ms keepalive polling enabled for the HS450 (same as the HS410).
-- `actions.time` (auto transition time control) and tally feedbacks enabled for the HS450.
+- Tally feedbacks enabled for the HS450. Auto transition *time* (`STIM`) is HS410_IF-only and is not offered for HS450 (set rates on the mixer; VS-R45/AUXP_IP has no STIM).
 - manifest `products` and `description` updated to include the AV-HS450.

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -17,6 +17,6 @@ Plugins for the AV-HS410 mixer can be found by creating a login and downloading 
 - Bus crosspoint control
 - Send AUTO transition
 - Send CUT transition
-- Auto transition time control (Not supported by AV-HS50)
+- Auto transition time control (Not supported by AV-HS50 or AV-HS450; set times on the mixer)
 
 For additional actions, please raise a feature request on [GitHub](https://github.com/bitfocus/companion-module-panasonic-avhs/).

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -1,22 +1,42 @@
 ## Panasonic AVHS
 
-This module will connect to the Panasonic AV-UHS500, AV-HS410 and AW-HS50 video switchers. To control the AV-HS410, you will need to install the plug-in software for external interface control.
+This module connects to Panasonic AV-UHS500, AV-HS450, AV-HS410, and AW-HS50 video switchers.
 
-If you want feedbacks to work on the AV-HS410 please enable both network plugins (AUXP_IP and HS410_IF)
-Plugins for the AV-HS410 mixer can be found by creating a login and downloading them directy from Panasonic: [Panasonic Support](https://eww.pass.panasonic.co.jp/p2ui/guest/TopLogin.do?lang=en&category=pav)
+### Plug-ins (AV-HS410)
+
+To control an AV-HS410 you need Panasonic’s network plug-ins. Download them from [Panasonic Support](https://eww.pass.panasonic.co.jp/p2ui/guest/TopLogin.do?lang=en&category=pav) (login required).
+
+| Goal | Plug-in | Module setting |
+|------|---------|----------------|
+| Control only (TCP 60040, HS410_IF) | **HS410_IF** | Multicast **off** |
+| Control + tally/feedback (TCP/UDP 60020, AUXP_IP) | **AUXP_IP** (+ HS410_IF if you also need STIM/etc.) | Multicast **on** |
+
+AV-HS450 uses AUXP_IP-compatible control on TCP **60020** with multicast tally on `224.0.0.200:60020` (no separate HS410_IF port).
+
+**Note:** With more than one AV-HS410 on the same multicast group, tally variables are shared and follow the first mixer only.
 
 ### Configuration
 
-- Type in the device IP address.
-- The device will communicate over port 60040 as default, this can be changed in the settings.
-
-**Note** When using this module with more than one AV-HS410, the variables will be mirrored on all instances of the module, and the values will only follow the first mixer. This is due to the multicast protocol implemented by Panasonic.
+- Enter the device IP address.
+- Default ports: **62000** (UHS500), **60020** (HS450; HS410 with multicast), **60040** (HS410 without multicast, HS50).
 
 ### Available actions
 
-- Bus crosspoint control
-- Send AUTO transition
-- Send CUT transition
-- Auto transition time control (Not supported by AV-HS50 or AV-HS450; set times on the mixer)
+- Bus crosspoint control (`SBUS`)
+- Send AUTO transition (`SAUT`) — toggles BKGD / KEY / DSK / PinP / FTB (model-dependent)
+- Send CUT transition (`SCUT`) — BKGD/KEY on AUXP_IP; broader on HS410_IF
+- Auto transition time (`STIM`) — HS410_IF / UHS500 only (not HS450 / HS50)
+
+### DSK on/off (#7)
+
+There is no separate “DSK cut” on AUXP_IP. Use **Send AUTO transition** with target **DSK** (HS410) or **DSK 1 / DSK 2** (HS450). That is the same as pressing AUTO on the mixer for that effect.
+
+With multicast enabled, **Auto Effect On** / AUTO presets use live `ATST` status (`05` = on) on HS450. HS410 AUXP_IP does not publish DSK in `ATST` (official table leaves slots 2–6 unused), so on/off feedback there is limited to what the mixer exposes.
+
+### PinP + multicast tally (#14)
+
+Enabling multicast on HS410 switches the module to **AUXP_IP** (port 60020, 2-field `SAUT`). PinP AUTO targets are `04`/`05` with `SAUT:<target>:0`. With multicast off, the module stays on **HS410_IF** (port 60040, 3-field `SAUT`).
+
+If PinP worked before enabling tally and stopped after, use the main **Send AUTO transition** action after updating to this build — it picks the correct SAUT shape from the multicast setting (you should not need the old “Auto (2)” workaround for that case).
 
 For additional actions, please raise a feature request on [GitHub](https://github.com/bitfocus/companion-module-panasonic-avhs/).

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -2,7 +2,7 @@
 	"id": "panasonic-avhs",
 	"name": "panasonic-avhs",
 	"shortname": "av-hs",
-	"description": "Companion module for Panasonic AV-HS450, AV-HS50, AV-HS410 and AV-UHS500",
+	"description": "Companion module for Panasonic AV-HS50, AV-HS410, AV-HS450 and AV-UHS500",
 	"version": "0.0.0",
 	"license": "MIT",
 	"repository": "git+https://github.com/bitfocus/companion-module-panasonic-avhs.git",
@@ -30,7 +30,7 @@
 	},
 	"manufacturer": "Panasonic",
 	"products": [
-		"AV-HS450 / AV-HS50 / AV-HS410 / AV-UHS500"
+		"AV-HS50 / AV-HS410 / AV-HS450 / AV-UHS500"
 	],
 	"keywords": [
 		"Vision Mixer",

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -30,7 +30,10 @@
 	},
 	"manufacturer": "Panasonic",
 	"products": [
-		"AV-HS50 / AV-HS410 / AV-HS450 / AV-UHS500"
+		"AV-HS50",
+		"AV-HS410",
+		"AV-HS450",
+		"AV-UHS500"
 	],
 	"keywords": [
 		"Vision Mixer",

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -2,7 +2,7 @@
 	"id": "panasonic-avhs",
 	"name": "panasonic-avhs",
 	"shortname": "av-hs",
-	"description": "Companion module for Panasonic AV-HS50, AV-HS410 and AV-UHS500",
+	"description": "Companion module for Panasonic AV-HS450, AV-HS50, AV-HS410 and AV-UHS500",
 	"version": "0.0.0",
 	"license": "MIT",
 	"repository": "git+https://github.com/bitfocus/companion-module-panasonic-avhs.git",
@@ -30,7 +30,7 @@
 	},
 	"manufacturer": "Panasonic",
 	"products": [
-		"AV-HS50 / AV-HS410 / AV-UHS500"
+		"AV-HS450 / AV-HS50 / AV-HS410 / AV-UHS500"
 	],
 	"keywords": [
 		"Vision Mixer",

--- a/index.js
+++ b/index.js
@@ -48,6 +48,10 @@ class avhsInstance extends InstanceBase {
 				aux2: '',
 				aux3: '',
 				aux4: '',
+				// HS450 source-bus entries (ABST buses 16-18)
+				aux1s: '',
+				pinP1s: '',
+				pinP2s: '',
 			},
 		}
 

--- a/index.js
+++ b/index.js
@@ -54,6 +54,8 @@ class avhsInstance extends InstanceBase {
 				aux1s: '',
 				pinP1s: '',
 				pinP2s: '',
+				// ATST:<target>:<state> auto-transition status (00=stop, 01=pause, 02=running)
+				autoTrans: {},
 			},
 		}
 

--- a/index.js
+++ b/index.js
@@ -42,6 +42,8 @@ class avhsInstance extends InstanceBase {
 				keyS: '',
 				dskF: '',
 				dskS: '',
+				dsk2F: '',
+				dsk2S: '',
 				pinP1: '',
 				pinP2: '',
 				aux1: '',
@@ -86,14 +88,12 @@ class avhsInstance extends InstanceBase {
 		await this.getNetworkInterfaces();
 
 		this.initActions();
+		this.initFeedbacks();
+		this.initVariables();
+		this.initPresets();
 
-		if (this.config.multicast == true) {
-			this.initFeedbacks()
-			this.initVariables()
-			
-			this.checkFeedbacks()
-			this.checkVariables()
-		}
+		this.checkFeedbacks();
+		this.checkVariables();
 
 		this.initConnection();
 	}

--- a/index.js
+++ b/index.js
@@ -54,8 +54,11 @@ class avhsInstance extends InstanceBase {
 				aux1s: '',
 				pinP1s: '',
 				pinP2s: '',
-				// ATST:<target>:<state> auto-transition status (00=stop, 01=pause, 02=running)
+				// ATST:<target>:<state> — 00 off, 01 pause, 02 BKGD run, 04/05/06 on-ramp/on/off-ramp
 				autoTrans: {},
+				// ATLY:<pvw_hex>:<pgm_hex> physical-input bitmasks (bit0=IN1 … bit19=IN20)
+				atlyPvw: 0,
+				atlyPgm: 0,
 			},
 		}
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -80,8 +80,8 @@ module.exports = {
 			}
 		};
 
-		actions.time = {
-			name: 'Auto transition time control (HS410)',
+	actions.time = {
+		name: 'Auto transition time control (HS410/HS450)',
 			options: [
 				{
 					label: 'Target',

--- a/src/actions.js
+++ b/src/actions.js
@@ -40,7 +40,9 @@ module.exports = {
 				},
 			],
 			callback: async function (action) {
-				if (self.config.model == 'HS50') {
+				// VS-R45 / AUXP_IP (HS450) and HS50 use SAUT:<target>:<op> (2 fields).
+				// HS410_IF / UHS500 use SAUT:<target>:<effect>:<op> (3 fields).
+				if (self.config.model == 'HS50' || self.config.model == 'HS450') {
 					self.sendCommand('SAUT:' + action.options.target + ':0');
 				} else {
 					self.sendCommand('SAUT:' + action.options.target + ':0:0');

--- a/src/actions.js
+++ b/src/actions.js
@@ -4,6 +4,7 @@ module.exports = {
 		let actions = {};
 
 		let model = self.config.model;
+		let sautTargets = self.getSautTargets()
 
 		actions.xpt = {
 			name: 'Bus crosspoint control',
@@ -35,14 +36,15 @@ module.exports = {
 					label: 'Target',
 					type: 'dropdown',
 					id: 'target',
-					choices: self[model + '_TARGETS'],
-					default: self[model + '_TARGETS'][0].id,
+					choices: sautTargets,
+					default: sautTargets[0].id,
 				},
 			],
 			callback: async function (action) {
-				// VS-R45 / AUXP_IP (HS450) and HS50 use SAUT:<target>:<op> (2 fields).
-				// HS410_IF / UHS500 use SAUT:<target>:<effect>:<op> (3 fields).
-				if (self.config.model == 'HS50' || self.config.model == 'HS450') {
+				// AUXP_IP (HS450, HS410+multicast) and HS50: SAUT:<target>:<op> (2 fields).
+				// Example from AUXP_IP Vol.2: SAUT:00:0 — DSK is target 02.
+				// HS410_IF / UHS500: SAUT:<target>:<effect>:<op> (3 fields); DSK is 07.
+				if (self.usesAuxpIpSaut()) {
 					self.sendCommand('SAUT:' + action.options.target + ':0');
 				} else {
 					self.sendCommand('SAUT:' + action.options.target + ':0:0');
@@ -57,12 +59,16 @@ module.exports = {
 					label: 'Target',
 					type: 'dropdown',
 					id: 'target',
-					choices: self[model + '_TARGETS'],
-					default: self[model + '_TARGETS'][0].id,
+					choices: sautTargets,
+					default: sautTargets[0].id,
 				},
 			],
 			callback: async function (action) {
-				self.sendCommand('SAUT:' + action.options.target + ':0');
+				if (self.usesAuxpIpSaut()) {
+					self.sendCommand('SAUT:' + action.options.target + ':0');
+				} else {
+					self.sendCommand('SAUT:' + action.options.target + ':0:0');
+				}
 			}
 		};
 
@@ -83,6 +89,8 @@ module.exports = {
 		};
 
 		if (model != 'HS50' && model != 'HS450') {
+			// STIM is HS410_IF / UHS500 only (not in AUXP_IP).
+			let stimTargets = self[model + '_TARGETS']
 			actions.time = {
 				name: 'Auto transition time control (HS410/UHS500)',
 				options: [
@@ -90,8 +98,8 @@ module.exports = {
 						label: 'Target',
 						type: 'dropdown',
 						id: 'target',
-						choices: self[model + '_TARGETS'],
-						default: self[model + '_TARGETS'][0].id,
+						choices: stimTargets,
+						default: stimTargets[0].id,
 					},
 					{
 						label: 'Time (in number of frames)',

--- a/src/actions.js
+++ b/src/actions.js
@@ -82,35 +82,32 @@ module.exports = {
 			}
 		};
 
-	actions.time = {
-		name: 'Auto transition time control (HS410/HS450)',
-			options: [
-				{
-					label: 'Target',
-					type: 'dropdown',
-					id: 'target',
-					choices: self[model + '_TARGETS'],
-					default: self[model + '_TARGETS'][0].id,
-				},
-				{
-					label: 'Time (in number of frames)',
-					type: 'textinput',
-					id: 'frames',
-					regex: '/^0*([0-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9])$/',
-				},
-			],
-			callback: async function (action) {
-				if (self.config.model == 'HS50') {
-					self.log('error', 'HS50 does not have support for setting auto transition times');
-					return;
+		if (model != 'HS50' && model != 'HS450') {
+			actions.time = {
+				name: 'Auto transition time control (HS410/UHS500)',
+				options: [
+					{
+						label: 'Target',
+						type: 'dropdown',
+						id: 'target',
+						choices: self[model + '_TARGETS'],
+						default: self[model + '_TARGETS'][0].id,
+					},
+					{
+						label: 'Time (in number of frames)',
+						type: 'textinput',
+						id: 'frames',
+						regex: '/^0*([0-9]|[1-8][0-9]|9[0-9]|[1-8][0-9]{2}|9[0-8][0-9]|99[0-9])$/',
+					},
+				],
+				callback: async function (action) {
+					if (parseInt(action.options.frames) > 999) {
+						action.options.frames = 999;
+					}
+					self.sendCommand('STIM:' + action.options.target + ':' + ('000' + parseInt(action.options.frames)).substr(-3));
 				}
-
-				if (parseInt(action.options.frames) > 999) {
-					action.options.frames = 999;
-				}
-				self.sendCommand('STIM:' + action.options.target + ':' + ('000' + parseInt(action.options.frames)).substr(-3));
-			}
-		};
+			};
+		}
 
 		self.setActionDefinitions(actions);
 	}

--- a/src/config.js
+++ b/src/config.js
@@ -15,7 +15,7 @@ module.exports = {
 				id: 'info2',
 				width: 12,
 				label: 'Information',
-				value: 'Default ports used in this module are 62000 for AV-UHS500, 60040 (60020 for multicast) for AV-HS410, and 60040 for AV-HS50.'
+				value: 'Default ports used in this module are 62000 for AV-UHS500, 60020 for AV-HS450, 60040 (60020 for multicast) for AV-HS410, and 60040 for AV-HS50.'
 			},
 			{
 				type: 'textinput',
@@ -29,12 +29,13 @@ module.exports = {
 				type: 'dropdown',
 				id: 'model',
 				label: 'Device Model',
-				choices: [
-					{ id: 'UHS500', label: 'AV-UHS500' },
-					{ id: 'HS410', label: 'AV-HS410' },
-					{ id: 'HS50', label: 'AW-HS50' },
-				],
-				default: 'HS410',
+			choices: [
+				{ id: 'UHS500', label: 'AV-UHS500' },
+				{ id: 'HS450', label: 'AV-HS450' },
+				{ id: 'HS410', label: 'AV-HS410' },
+				{ id: 'HS50', label: 'AW-HS50' },
+			],
+			default: 'HS410',
 				width: 6,
 			},
 			{
@@ -43,7 +44,7 @@ module.exports = {
 				width: 12,
 				label: 'Variables and AV-HS410 Support',
 				value: 'Make sure you have Multicast traffic enabled on your network. If multicast is disabled, then variables will not work with the AV-HS410',
-				isVisible: (config) => config.model == 'HS410'
+				isVisible: (config) => config.model == 'HS410' || config.model == 'HS450'
 			},
 			{
 				type: 'checkbox',
@@ -51,15 +52,15 @@ module.exports = {
 				width: 1,
 				label: 'Enable',
 				default: false,
-				isVisible: (config) => config.model == 'HS410'
+				isVisible: (config) => config.model == 'HS410' || config.model == 'HS450'
 			},
 			{
 				type: 'static-text',
 				id: 'multicastInfo',
 				width: 11,
 				label: 'Enable Multicast Support (Tally Info)',
-				value: 'If you are using an AV-HS410, enable this for multicast tally support, giving you variables and feedbacks for tally.',
-				isVisible: (config) => config.model == 'HS410'
+				value: 'If you are using an AV-HS410 or AV-HS450, enable this for multicast tally support, giving you variables and feedbacks for tally.',
+				isVisible: (config) => config.model == 'HS410' || config.model == 'HS450'
 			},
 		]
 	},

--- a/src/constants.js
+++ b/src/constants.js
@@ -42,12 +42,12 @@ module.exports = {
 		{ id: '15', label: 'Aux 4' },
 	],
 
-	// AV-HS450: same bus layout as the AV-HS410 (02=PGM, 03=PVW, ...),
-	// verified live. The HS450 has 32 XPT buttons (XPT1-32 = source ids 00-31),
-	// 20 physical inputs (16 SDI + 2x optional cards with 2 inputs each = source 50-69),
-	// and the internal signals (CBAR, CBGD, Black, FMEM1-4, PGM, PVW, KEYOUT, CLN,
-	// MV1, MV2, ...). FMEM1-4 are the HS450 names for source ids 73-76
-	// (the HS410 spec labels them Still1V/Still2V/Clip1V/Clip2V).
+	// AV-HS450: same bus layout as the AV-HS410 for shared buses (02=PGM, 03=PVW, ...),
+	// verified live. Buses 08/09 are unused on the HS410 AUXP_IP spec but are active
+	// on the HS450 as DSK2 Fill/Source (seen populated in live ABST XPT maps).
+	// The HS450 has 32 XPT buttons (XPT1-32 = source ids 00-31), 20 physical inputs
+	// (16 SDI + 2x optional cards with 2 inputs each = source 50-69), and internal
+	// signals (CBAR, CBGD, Black, FMEM1-4, PGM, PVW, KEYOUT, CLN, MV1, MV2, ...).
 	HS450_BUS: [
 		{ id: '02', label: 'PGM' },
 		{ id: '03', label: 'PVW' },
@@ -55,8 +55,10 @@ module.exports = {
 		{ id: '01', label: 'Bus B' },
 		{ id: '04', label: 'Key Fill' },
 		{ id: '05', label: 'Key Source' },
-		{ id: '06', label: 'DSK Fill' },
-		{ id: '07', label: 'DSK Source' },
+		{ id: '06', label: 'DSK1 Fill' },
+		{ id: '07', label: 'DSK1 Source' },
+		{ id: '08', label: 'DSK2 Fill' },
+		{ id: '09', label: 'DSK2 Source' },
 		{ id: '10', label: 'PinP 1' },
 		{ id: '11', label: 'PinP 2' },
 		{ id: '12', label: 'Aux 1' },
@@ -182,7 +184,8 @@ module.exports = {
 	// (16 SDI + 2x2 optional cards = source 50-69), and internal signals. The HS450 labels
 	// source ids 73-76 as FMEM1-4 (frame memories); the HS410 spec labels them Still1V/
 	// Still2V/Clip1V/Clip2V. MV1/MV2 (source 81/82) are the two multi-view lines (the HS410
-	// spec lists only one MV at 81).
+	// spec lists only one MV at 81). MV1-1..16 / MV2-1..16 (153-184) are the 16 sub-windows
+	// per multi-view line (HS450-specific; the HS410 had no per-pane sources).
 	HS450_INPUTS: [
 		{ id: '00', label: 'XPT 1' }, { id: '01', label: 'XPT 2' }, { id: '02', label: 'XPT 3' },
 		{ id: '03', label: 'XPT 4' }, { id: '04', label: 'XPT 5' }, { id: '05', label: 'XPT 6' },
@@ -210,6 +213,18 @@ module.exports = {
 		{ id: '91', label: 'M-PVW' }, { id: '92', label: 'Still1K' },
 		{ id: '93', label: 'Still2K' }, { id: '94', label: 'Clip1K' }, { id: '95', label: 'Clip2K' },
 		{ id: '96', label: 'CBGD2' }, { id: '99', label: 'No selection' },
+		{ id: '153', label: 'MV1-1' }, { id: '154', label: 'MV1-2' }, { id: '155', label: 'MV1-3' },
+		{ id: '156', label: 'MV1-4' }, { id: '157', label: 'MV1-5' }, { id: '158', label: 'MV1-6' },
+		{ id: '159', label: 'MV1-7' }, { id: '160', label: 'MV1-8' }, { id: '161', label: 'MV1-9' },
+		{ id: '162', label: 'MV1-10' }, { id: '163', label: 'MV1-11' }, { id: '164', label: 'MV1-12' },
+		{ id: '165', label: 'MV1-13' }, { id: '166', label: 'MV1-14' }, { id: '167', label: 'MV1-15' },
+		{ id: '168', label: 'MV1-16' },
+		{ id: '169', label: 'MV2-1' }, { id: '170', label: 'MV2-2' }, { id: '171', label: 'MV2-3' },
+		{ id: '172', label: 'MV2-4' }, { id: '173', label: 'MV2-5' }, { id: '174', label: 'MV2-6' },
+		{ id: '175', label: 'MV2-7' }, { id: '176', label: 'MV2-8' }, { id: '177', label: 'MV2-9' },
+		{ id: '178', label: 'MV2-10' }, { id: '179', label: 'MV2-11' }, { id: '180', label: 'MV2-12' },
+		{ id: '181', label: 'MV2-13' }, { id: '182', label: 'MV2-14' }, { id: '183', label: 'MV2-15' },
+		{ id: '184', label: 'MV2-16' },
 	],
 
 	HS50_INPUTS: [
@@ -259,24 +274,27 @@ module.exports = {
 		{ id: '07', label: 'DSK' },
 	],
 
-	// AV-HS450: same transition targets as the AV-HS410.
+	// AV-HS450: HS410 targets plus DSK2. Target 07 is DSK1 (same id the stock
+	// module uses for the single HS410 DSK); 08 is DSK2 (matches UHS500 DSK2
+	// numbering and the second DSK on the HS450 panel).
 	HS450_TARGETS: [
 		{ id: '00', label: 'BKGD' },
 		{ id: '01', label: 'KEY' },
 		{ id: '04', label: 'PinP 1' },
 		{ id: '05', label: 'PinP 2' },
 		{ id: '06', label: 'FTB' },
-		{ id: '07', label: 'DSK' },
+		{ id: '07', label: 'DSK 1' },
+		{ id: '08', label: 'DSK 2' },
 	],
 
-	// AV-HS450: same cut targets as the AV-HS410.
 	HS450_CUTTARGETS: [
 		{ id: '00', label: 'BKGD' },
 		{ id: '01', label: 'KEY' },
 		{ id: '04', label: 'PinP 1' },
 		{ id: '05', label: 'PinP 2' },
 		{ id: '06', label: 'FTB' },
-		{ id: '07', label: 'DSK' },
+		{ id: '07', label: 'DSK 1' },
+		{ id: '08', label: 'DSK 2' },
 	],
 	
 	HS50_TARGETS: [

--- a/src/constants.js
+++ b/src/constants.js
@@ -254,6 +254,7 @@ module.exports = {
 		{ id: '08', label: 'DSK 2' },
 	],
 	
+	// HS410_IF (TCP 60040): 3-field SAUT; DSK is target 07.
 	HS410_TARGETS: [
 		{ id: '00', label: 'BKGD' },
 		{ id: '01', label: 'KEY' },
@@ -261,6 +262,18 @@ module.exports = {
 		{ id: '05', label: 'PinP 2' },
 		{ id: '06', label: 'FTB' },
 		{ id: '07', label: 'DSK' },
+	],
+
+	// AUXP_IP Vol.2 SAUT (TCP 60020, 2 fields). Official table:
+	// 00=BKGD, 01=KEY, 02=DSK, 03=-, 04=PinP1, 05=PinP2, 06=FTB.
+	// Used when HS410 multicast/AUXP_IP is enabled (same port as HS450).
+	HS410_AUXP_TARGETS: [
+		{ id: '00', label: 'BKGD' },
+		{ id: '01', label: 'KEY' },
+		{ id: '02', label: 'DSK' },
+		{ id: '04', label: 'PinP 1' },
+		{ id: '05', label: 'PinP 2' },
+		{ id: '06', label: 'FTB' },
 	],
 
 	// AV-HS450 uses AUXP_IP on TCP 60020 (not HS410_IF on 60040). AUXP_IP
@@ -300,9 +313,9 @@ module.exports = {
 	// States that mean an auto transition is in progress (not steady on/off).
 	ATST_RUNNING_STATES: ['02', '04', '06'],
 
-	// ATST parameter-1 targets. HS450 uses SAUT ids on the wire (0=BKGD … 6=FTB,
-	// 7=AUX); 8/9 are PinP buses on the HS410 AUXP_IP table.
-	ATST_TARGETS: [
+	// HS450 ATST targets match SAUT ids (confirmed live). No PinP1Bus/PinP2Bus
+	// slots — those are HS410 AUXP_IP panel-mode ids 8/9.
+	HS450_ATST_TARGETS: [
 		{ id: '0', label: 'BKGD' },
 		{ id: '1', label: 'KEY' },
 		{ id: '2', label: 'DSK 1' },
@@ -311,10 +324,17 @@ module.exports = {
 		{ id: '5', label: 'PinP 2' },
 		{ id: '6', label: 'FTB' },
 		{ id: '7', label: 'AUX' },
+	],
+
+	// HS410 AUXP_IP ATST table: 2–6 unused; PinP status is 8/9 (…Bus), not 4/5.
+	HS410_ATST_TARGETS: [
+		{ id: '0', label: 'BKGD' },
+		{ id: '1', label: 'KEY' },
+		{ id: '7', label: 'AUX' },
 		{ id: '8', label: 'PinP 1 Bus' },
 		{ id: '9', label: 'PinP 2 Bus' },
 	],
-	
+
 	HS50_TARGETS: [
 		{ id: '00', label: 'BKGD' },
 		{ id: '01', label: 'KEY' },

--- a/src/constants.js
+++ b/src/constants.js
@@ -183,9 +183,10 @@ module.exports = {
 	// AV-HS450: 32 XPT buttons (XPT1-32 = source ids 00-31), 20 physical inputs
 	// (16 SDI + 2x2 optional cards = source 50-69), and internal signals. The HS450 labels
 	// source ids 73-76 as FMEM1-4 (frame memories); the HS410 spec labels them Still1V/
-	// Still2V/Clip1V/Clip2V. MV1/MV2 (source 81/82) are the two multi-view lines (the HS410
-	// spec lists only one MV at 81). MV1-1..16 / MV2-1..16 (153-184) are the 16 sub-windows
-	// per multi-view line (HS450-specific; the HS410 had no per-pane sources).
+	// Still2V/Clip1V/Clip2V. MV1/MV2 (source 81/82) are the two multi-view outputs
+	// (the HS410 spec lists only one MV at 81). Individual MV panes (UHS500/HS6000
+	// buses 153-184) are not addressable over AUXP_IP: SBUS is SBUS:%02d:%02d
+	// (two-digit bus and source), and VS-R45 has no MV-pane command.
 	HS450_INPUTS: [
 		{ id: '00', label: 'XPT 1' }, { id: '01', label: 'XPT 2' }, { id: '02', label: 'XPT 3' },
 		{ id: '03', label: 'XPT 4' }, { id: '04', label: 'XPT 5' }, { id: '05', label: 'XPT 6' },
@@ -213,18 +214,6 @@ module.exports = {
 		{ id: '91', label: 'M-PVW' }, { id: '92', label: 'Still1K' },
 		{ id: '93', label: 'Still2K' }, { id: '94', label: 'Clip1K' }, { id: '95', label: 'Clip2K' },
 		{ id: '96', label: 'CBGD2' }, { id: '99', label: 'No selection' },
-		{ id: '153', label: 'MV1-1' }, { id: '154', label: 'MV1-2' }, { id: '155', label: 'MV1-3' },
-		{ id: '156', label: 'MV1-4' }, { id: '157', label: 'MV1-5' }, { id: '158', label: 'MV1-6' },
-		{ id: '159', label: 'MV1-7' }, { id: '160', label: 'MV1-8' }, { id: '161', label: 'MV1-9' },
-		{ id: '162', label: 'MV1-10' }, { id: '163', label: 'MV1-11' }, { id: '164', label: 'MV1-12' },
-		{ id: '165', label: 'MV1-13' }, { id: '166', label: 'MV1-14' }, { id: '167', label: 'MV1-15' },
-		{ id: '168', label: 'MV1-16' },
-		{ id: '169', label: 'MV2-1' }, { id: '170', label: 'MV2-2' }, { id: '171', label: 'MV2-3' },
-		{ id: '172', label: 'MV2-4' }, { id: '173', label: 'MV2-5' }, { id: '174', label: 'MV2-6' },
-		{ id: '175', label: 'MV2-7' }, { id: '176', label: 'MV2-8' }, { id: '177', label: 'MV2-9' },
-		{ id: '178', label: 'MV2-10' }, { id: '179', label: 'MV2-11' }, { id: '180', label: 'MV2-12' },
-		{ id: '181', label: 'MV2-13' }, { id: '182', label: 'MV2-14' }, { id: '183', label: 'MV2-15' },
-		{ id: '184', label: 'MV2-16' },
 	],
 
 	HS50_INPUTS: [

--- a/src/constants.js
+++ b/src/constants.js
@@ -274,27 +274,25 @@ module.exports = {
 		{ id: '07', label: 'DSK' },
 	],
 
-	// AV-HS450: HS410 targets plus DSK2. Target 07 is DSK1 (same id the stock
-	// module uses for the single HS410 DSK); 08 is DSK2 (matches UHS500 DSK2
-	// numbering and the second DSK on the HS450 panel).
+	// AV-HS450 uses AUXP_IP on TCP 60020 (not HS410_IF on 60040). AUXP_IP
+	// SAUT targets are: 00=BKGD, 01=KEY, 02=DSK1, 03=DSK2 (unused on HS410),
+	// 04=PinP1, 05=PinP2, 06=FTB. The stock module's 07=DSK id is HS410_IF
+	// only. SCUT is only implemented for BKGD/KEY on the HS450 (confirmed
+	// live); DSK/PinP/FTB have AUTO only — there is no cut command in AUXP_IP
+	// or the VS-R45 firmware (SAUT:%02d:%d, no SCUT/STIM).
 	HS450_TARGETS: [
 		{ id: '00', label: 'BKGD' },
 		{ id: '01', label: 'KEY' },
+		{ id: '02', label: 'DSK 1' },
+		{ id: '03', label: 'DSK 2' },
 		{ id: '04', label: 'PinP 1' },
 		{ id: '05', label: 'PinP 2' },
 		{ id: '06', label: 'FTB' },
-		{ id: '07', label: 'DSK 1' },
-		{ id: '08', label: 'DSK 2' },
 	],
 
 	HS450_CUTTARGETS: [
 		{ id: '00', label: 'BKGD' },
 		{ id: '01', label: 'KEY' },
-		{ id: '04', label: 'PinP 1' },
-		{ id: '05', label: 'PinP 2' },
-		{ id: '06', label: 'FTB' },
-		{ id: '07', label: 'DSK 1' },
-		{ id: '08', label: 'DSK 2' },
 	],
 	
 	HS50_TARGETS: [

--- a/src/constants.js
+++ b/src/constants.js
@@ -283,6 +283,28 @@ module.exports = {
 		{ id: '00', label: 'BKGD' },
 		{ id: '01', label: 'KEY' },
 	],
+
+	// ATST parameter-2 values (AUXP_IP auto-transition status).
+	ATST_STATES: [
+		{ id: '00', label: 'Stop' },
+		{ id: '01', label: 'Pause (BKGD only)' },
+		{ id: '02', label: 'Running' },
+	],
+
+	// ATST parameter-1 targets (AUXP_IP). HS410/HS450 share the 0..7 slots
+	// observed on multicast (0=BKGD, 7=AUX); 8/9 are PinP buses on HS410 spec.
+	ATST_TARGETS: [
+		{ id: '0', label: 'BKGD' },
+		{ id: '1', label: 'KEY' },
+		{ id: '2', label: 'DSK' },
+		{ id: '3', label: 'DSK 2' },
+		{ id: '4', label: 'PinP 1' },
+		{ id: '5', label: 'PinP 2' },
+		{ id: '6', label: 'FTB' },
+		{ id: '7', label: 'AUX' },
+		{ id: '8', label: 'PinP 1 Bus' },
+		{ id: '9', label: 'PinP 2 Bus' },
+	],
 	
 	HS50_TARGETS: [
 		{ id: '00', label: 'BKGD' },

--- a/src/constants.js
+++ b/src/constants.js
@@ -284,19 +284,28 @@ module.exports = {
 		{ id: '01', label: 'KEY' },
 	],
 
-	// ATST parameter-2 values (AUXP_IP auto-transition status).
+	// ATST parameter-2 values. AUXP_IP documents 00/01/02; HS450 also emits
+	// 04/05/06 for KEY/DSK/PinP/FTB (confirmed live):
+	//   00=off/stop, 01=pause (BKGD), 02=BKGD running,
+	//   04=transitioning on, 05=on (steady), 06=transitioning off.
 	ATST_STATES: [
-		{ id: '00', label: 'Stop' },
+		{ id: '00', label: 'Off / Stop' },
 		{ id: '01', label: 'Pause (BKGD only)' },
-		{ id: '02', label: 'Running' },
+		{ id: '02', label: 'Running (BKGD)' },
+		{ id: '04', label: 'Transitioning On' },
+		{ id: '05', label: 'On' },
+		{ id: '06', label: 'Transitioning Off' },
 	],
 
-	// ATST parameter-1 targets (AUXP_IP). HS410/HS450 share the 0..7 slots
-	// observed on multicast (0=BKGD, 7=AUX); 8/9 are PinP buses on HS410 spec.
+	// States that mean an auto transition is in progress (not steady on/off).
+	ATST_RUNNING_STATES: ['02', '04', '06'],
+
+	// ATST parameter-1 targets. HS450 uses SAUT ids on the wire (0=BKGD … 6=FTB,
+	// 7=AUX); 8/9 are PinP buses on the HS410 AUXP_IP table.
 	ATST_TARGETS: [
 		{ id: '0', label: 'BKGD' },
 		{ id: '1', label: 'KEY' },
-		{ id: '2', label: 'DSK' },
+		{ id: '2', label: 'DSK 1' },
 		{ id: '3', label: 'DSK 2' },
 		{ id: '4', label: 'PinP 1' },
 		{ id: '5', label: 'PinP 2' },

--- a/src/constants.js
+++ b/src/constants.js
@@ -41,6 +41,29 @@ module.exports = {
 		{ id: '14', label: 'Aux 3' },
 		{ id: '15', label: 'Aux 4' },
 	],
+
+	// AV-HS450: same bus layout as the AV-HS410 (02=PGM, 03=PVW, ...),
+	// verified live. The HS450 has 32 XPT buttons (XPT1-32 = source ids 00-31),
+	// 20 physical inputs (16 SDI + 2x optional cards with 2 inputs each = source 50-69),
+	// and the internal signals (CBAR, CBGD, Black, FMEM1-4, PGM, PVW, KEYOUT, CLN,
+	// MV1, MV2, ...). FMEM1-4 are the HS450 names for source ids 73-76
+	// (the HS410 spec labels them Still1V/Still2V/Clip1V/Clip2V).
+	HS450_BUS: [
+		{ id: '02', label: 'PGM' },
+		{ id: '03', label: 'PVW' },
+		{ id: '00', label: 'Bus A' },
+		{ id: '01', label: 'Bus B' },
+		{ id: '04', label: 'Key Fill' },
+		{ id: '05', label: 'Key Source' },
+		{ id: '06', label: 'DSK Fill' },
+		{ id: '07', label: 'DSK Source' },
+		{ id: '10', label: 'PinP 1' },
+		{ id: '11', label: 'PinP 2' },
+		{ id: '12', label: 'Aux 1' },
+		{ id: '13', label: 'Aux 2' },
+		{ id: '14', label: 'Aux 3' },
+		{ id: '15', label: 'Aux 4' },
+	],
 	
 	HS50_BUS: [
 		{ id: '02', label: 'PGM' },
@@ -152,9 +175,43 @@ module.exports = {
 		{ id: '93', label: 'Still2K' },
 		{ id: '94', label: 'Clip1K' },
 		{ id: '95', label: 'Clip2K' },
-		{ id: '99', label: 'No selection' },
+	{ id: '99', label: 'No selection' },
 	],
-	
+
+	// AV-HS450: 32 XPT buttons (XPT1-32 = source ids 00-31), 20 physical inputs
+	// (16 SDI + 2x2 optional cards = source 50-69), and internal signals. The HS450 labels
+	// source ids 73-76 as FMEM1-4 (frame memories); the HS410 spec labels them Still1V/
+	// Still2V/Clip1V/Clip2V. MV1/MV2 (source 81/82) are the two multi-view lines (the HS410
+	// spec lists only one MV at 81).
+	HS450_INPUTS: [
+		{ id: '00', label: 'XPT 1' }, { id: '01', label: 'XPT 2' }, { id: '02', label: 'XPT 3' },
+		{ id: '03', label: 'XPT 4' }, { id: '04', label: 'XPT 5' }, { id: '05', label: 'XPT 6' },
+		{ id: '06', label: 'XPT 7' }, { id: '07', label: 'XPT 8' }, { id: '08', label: 'XPT 9' },
+		{ id: '09', label: 'XPT 10' }, { id: '10', label: 'XPT 11' }, { id: '11', label: 'XPT 12' },
+		{ id: '12', label: 'XPT 13' }, { id: '13', label: 'XPT 14' }, { id: '14', label: 'XPT 15' },
+		{ id: '15', label: 'XPT 16' }, { id: '16', label: 'XPT 17' }, { id: '17', label: 'XPT 18' },
+		{ id: '18', label: 'XPT 19' }, { id: '19', label: 'XPT 20' }, { id: '20', label: 'XPT 21' },
+		{ id: '21', label: 'XPT 22' }, { id: '22', label: 'XPT 23' }, { id: '23', label: 'XPT 24' },
+		{ id: '24', label: 'XPT 25' }, { id: '25', label: 'XPT 26' }, { id: '26', label: 'XPT 27' },
+		{ id: '27', label: 'XPT 28' }, { id: '28', label: 'XPT 29' }, { id: '29', label: 'XPT 30' },
+		{ id: '30', label: 'XPT 31' }, { id: '31', label: 'XPT 32' },
+		{ id: '50', label: 'Input 1' }, { id: '51', label: 'Input 2' }, { id: '52', label: 'Input 3' },
+		{ id: '53', label: 'Input 4' }, { id: '54', label: 'Input 5' }, { id: '55', label: 'Input 6' },
+		{ id: '56', label: 'Input 7' }, { id: '57', label: 'Input 8' }, { id: '58', label: 'Input 9' },
+		{ id: '59', label: 'Input 10' }, { id: '60', label: 'Input 11' }, { id: '61', label: 'Input 12' },
+		{ id: '62', label: 'Input 13' }, { id: '63', label: 'Input 14' }, { id: '64', label: 'Input 15' },
+		{ id: '65', label: 'Input 16' }, { id: '66', label: 'Input 17' }, { id: '67', label: 'Input 18' },
+		{ id: '68', label: 'Input 19' }, { id: '69', label: 'Input 20' },
+		{ id: '70', label: 'Color Bar' }, { id: '71', label: 'CBGD' }, { id: '72', label: 'Black' },
+		{ id: '73', label: 'FMEM1' }, { id: '74', label: 'FMEM2' }, { id: '75', label: 'FMEM3' },
+		{ id: '76', label: 'FMEM4' }, { id: '77', label: 'PGM' }, { id: '78', label: 'PVW' },
+		{ id: '79', label: 'KeyOut' }, { id: '80', label: 'CLN' },
+		{ id: '81', label: 'MV1' }, { id: '82', label: 'MV2' },
+		{ id: '91', label: 'M-PVW' }, { id: '92', label: 'Still1K' },
+		{ id: '93', label: 'Still2K' }, { id: '94', label: 'Clip1K' }, { id: '95', label: 'Clip2K' },
+		{ id: '96', label: 'CBGD2' }, { id: '99', label: 'No selection' },
+	],
+
 	HS50_INPUTS: [
 		{ id: '00', label: 'XPT 1' },
 		{ id: '01', label: 'XPT 2' },
@@ -194,6 +251,26 @@ module.exports = {
 	],
 	
 	HS410_TARGETS: [
+		{ id: '00', label: 'BKGD' },
+		{ id: '01', label: 'KEY' },
+		{ id: '04', label: 'PinP 1' },
+		{ id: '05', label: 'PinP 2' },
+		{ id: '06', label: 'FTB' },
+		{ id: '07', label: 'DSK' },
+	],
+
+	// AV-HS450: same transition targets as the AV-HS410.
+	HS450_TARGETS: [
+		{ id: '00', label: 'BKGD' },
+		{ id: '01', label: 'KEY' },
+		{ id: '04', label: 'PinP 1' },
+		{ id: '05', label: 'PinP 2' },
+		{ id: '06', label: 'FTB' },
+		{ id: '07', label: 'DSK' },
+	],
+
+	// AV-HS450: same cut targets as the AV-HS410.
+	HS450_CUTTARGETS: [
 		{ id: '00', label: 'BKGD' },
 		{ id: '01', label: 'KEY' },
 		{ id: '04', label: 'PinP 1' },

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -11,8 +11,8 @@ module.exports = {
 		let model = self.config.model
 		let inputs = self[model + '_INPUTS'].slice(0, 24) // Only get the valid range of inputs for tally feedbacks
 
-		// Only avaliable for HS410
-		if (self.config.model == 'HS410') {
+	// Available for HS410 and HS450 (both push tally via multicast)
+	if (self.config.model == 'HS410' || self.config.model == 'HS450') {
 			feedbacks.tally = {
 				type: 'boolean',
 				name: 'Tally Feedback',

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -17,6 +17,18 @@ module.exports = {
 		if (xptChoices.length === 0) {
 			xptChoices = inputs
 		}
+		// ATLY is a physical-input bitmap (IN1…), not XPT buttons.
+		let physicalInputs = inputs.filter((i) => /^Input\s+\d+/i.test(i.label))
+		if (physicalInputs.length === 0) {
+			physicalInputs = inputs.filter((i) => {
+				let n = parseInt(i.id, 10)
+				return n >= 50 && n <= 69
+			})
+		}
+		const atlyBuses = [
+			{ id: '02', label: 'PGM' },
+			{ id: '03', label: 'PVW' },
+		]
 
 		feedbacks.tally = {
 			type: 'boolean',
@@ -104,11 +116,50 @@ module.exports = {
 		}
 
 		if (self.config.model == 'HS410' || self.config.model == 'HS450') {
+			const runningStates = self.ATST_RUNNING_STATES || ['02', '04', '06']
+
+			feedbacks.atly_tally = {
+				type: 'boolean',
+				name: 'ATLY Input Tally (PGM/PVW)',
+				description:
+					'True when ATLY reports the selected physical input on PGM (red) or PVW (green). Bit0=Input 1 … — independent of XPT button mapping. Requires multicast.',
+				defaultStyle: {
+					color: foregroundColor,
+					bgcolor: backgroundColor,
+				},
+				options: [
+					{
+						label: 'BUS',
+						type: 'dropdown',
+						id: 'bus',
+						choices: atlyBuses,
+						default: '02',
+					},
+					{
+						label: 'Input',
+						type: 'dropdown',
+						id: 'input',
+						choices: physicalInputs,
+						default: physicalInputs[0] ? physicalInputs[0].id : '50',
+					},
+				],
+				callback: function (feedback) {
+					const opt = feedback.options
+					const src = parseInt(opt.input, 10)
+					if (!Number.isFinite(src) || src < 50 || src > 69) {
+						return false
+					}
+					const bit = src - 50
+					const mask = opt.bus === '03' ? self.data.tally.atlyPvw : self.data.tally.atlyPgm
+					return ((mask >>> 0) & (1 << bit)) !== 0
+				},
+			}
+
 			feedbacks.auto_status = {
 				type: 'boolean',
 				name: 'Auto Transition Status',
 				description:
-					'True when an ATST target matches the selected auto-transition state (00=stop, 01=pause, 02=running)',
+					'True when an ATST target matches the selected state (00=off, 01=pause, 02=BKGD running, 04=on-ramp, 05=on, 06=off-ramp)',
 				defaultStyle: {
 					color: combineRgb(255, 255, 255),
 					bgcolor: combineRgb(0, 180, 0),
@@ -126,7 +177,7 @@ module.exports = {
 						type: 'dropdown',
 						id: 'state',
 						choices: self.ATST_STATES,
-						default: '02',
+						default: '05',
 					},
 				],
 				callback: function (feedback) {
@@ -139,7 +190,8 @@ module.exports = {
 			feedbacks.auto_running = {
 				type: 'boolean',
 				name: 'Auto Transition Running',
-				description: 'True when any ATST target reports state 02 (transition running)',
+				description:
+					'True when any ATST target is transitioning (02 BKGD, or 04/06 for KEY/DSK/PinP/FTB)',
 				defaultStyle: {
 					color: combineRgb(255, 255, 255),
 					bgcolor: combineRgb(255, 140, 0),
@@ -147,7 +199,55 @@ module.exports = {
 				options: [],
 				callback: function () {
 					const auto = self.data.tally.autoTrans || {}
-					return Object.values(auto).some((code) => code === '02')
+					return Object.values(auto).some((code) => runningStates.includes(code))
+				},
+			}
+
+			feedbacks.auto_target_running = {
+				type: 'boolean',
+				name: 'Auto Transition Running (Target)',
+				description:
+					'True when the selected ATST target is transitioning (02/04/06)',
+				defaultStyle: {
+					color: combineRgb(255, 255, 255),
+					bgcolor: combineRgb(255, 140, 0),
+				},
+				options: [
+					{
+						label: 'Target',
+						type: 'dropdown',
+						id: 'target',
+						choices: self.ATST_TARGETS,
+						default: '0',
+					},
+				],
+				callback: function (feedback) {
+					const auto = self.data.tally.autoTrans || {}
+					const current = auto[feedback.options.target]
+					return runningStates.includes(current)
+				},
+			}
+
+			feedbacks.auto_target_on = {
+				type: 'boolean',
+				name: 'Auto Effect On (Target)',
+				description: 'True when the selected ATST target reports state 05 (on)',
+				defaultStyle: {
+					color: combineRgb(255, 255, 255),
+					bgcolor: combineRgb(0, 180, 0),
+				},
+				options: [
+					{
+						label: 'Target',
+						type: 'dropdown',
+						id: 'target',
+						choices: self.ATST_TARGETS,
+						default: '1',
+					},
+				],
+				callback: function (feedback) {
+					const auto = self.data.tally.autoTrans || {}
+					return auto[feedback.options.target] === '05'
 				},
 			}
 		}

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -9,120 +9,94 @@ module.exports = {
 		const backgroundColor = combineRgb(255, 0, 0) // Red
 
 		let model = self.config.model
-		let inputs = self[model + '_INPUTS'].slice(0, 24) // Only get the valid range of inputs for tally feedbacks
+		let buses = self[model + '_BUS'] || []
+		let inputs = self[model + '_INPUTS'] || []
 
-	// Available for HS410 and HS450 (both push tally via multicast)
-	if (self.config.model == 'HS410' || self.config.model == 'HS450') {
-			feedbacks.tally = {
-				type: 'boolean',
-				name: 'Tally Feedback',
-				description: 'Indicate if Camera is selected on a bus',
-				defaultStyle: {
-					color: foregroundColor,
-					bgcolor: backgroundColor,
+		feedbacks.tally = {
+			type: 'boolean',
+			name: 'Tally Feedback',
+			description:
+				'True when the selected XPT/source is currently selected on the bus. Requires multicast tally (HS410/HS450); on other models this stays off.',
+			defaultStyle: {
+				color: foregroundColor,
+				bgcolor: backgroundColor,
+			},
+			options: [
+				{
+					label: 'BUS',
+					type: 'dropdown',
+					id: 'bus',
+					choices: buses,
+					default: buses[0] ? buses[0].id : '02',
 				},
-				options: [
-					{
-						label: 'BUS',
-						type: 'dropdown',
-						id: 'bus',
-						choices: self[model + '_BUS'],
-						default: self[model + '_BUS'][0].id,
-					},
-					{
-						label: 'Input',
-						type: 'dropdown',
-						id: 'input',
-						choices: inputs,
-						default: inputs[0].id,
-					},
-				],
-				callback: function (feedback, bank) {
-					let opt = feedback.options
-					let tally = self.data.tally
+				{
+					label: 'Input',
+					type: 'dropdown',
+					id: 'input',
+					choices: inputs,
+					default: inputs[0] ? inputs[0].id : '00',
+				},
+			],
+			callback: function (feedback) {
+				let opt = feedback.options
+				let tally = self.data.tally
+				let inputsList = self[self.config.model + '_INPUTS'] || []
 
-					let input = self.HS410_INPUTS.find(({ id }) => id === opt.input).label
-
-					// Only avaliable with HS410
-					switch (opt.bus) {
-						case '00':
-							if (input == tally.busA) {
-								return true
-							}
-							break // Bus A
-						case '01':
-							if (input == tally.busB) {
-								return true
-							}
-							break // Bus B
-						case '02':
-							if (input == tally.pgm) {
-								return true
-							}
-							break // PGM
-						case '03':
-							if (input == tally.pvw) {
-								return true
-							}
-							break // PVW
-						case '04':
-							if (input == tally.keyF) {
-								return true
-							}
-							break // Key Fill
-						case '05':
-							if (input == tally.keyS) {
-								return true
-							}
-							break // Key Source
-						case '06':
-							if (input == tally.dskF) {
-								return true
-							}
-							break // DSK Fill
-						case '07':
-							if (input == tally.dskS) {
-								return true
-							}
-							break // DSK Source
-						case '10':
-							if (input == tally.pinP1) {
-								return true
-							}
-							break // PinP 1
-						case '11':
-							if (input == tally.pinP2) {
-								return true
-							}
-							break // PinP 2
-						case '12':
-							if (input == tally.aux1) {
-								return true
-							}
-							break // AUX 1
-						case '13':
-							if (input == tally.aux2) {
-								return true
-							}
-							break // AUX 2
-						case '14':
-							if (input == tally.aux3) {
-								return true
-							}
-							break // AUX 3
-						case '15':
-							if (input == tally.aux4) {
-								return true
-							}
-							break // AUX 4
-						default:
-							return false
-					}
+				let inputEntry = inputsList.find(({ id }) => id === opt.input)
+				if (!inputEntry) {
+					let padded = String(opt.input || '').padStart(2, '0')
+					inputEntry = inputsList.find(({ id }) => id === padded)
+				}
+				if (!inputEntry) {
 					return false
-				},
-			}
+				}
+				let input = inputEntry.label
+
+				switch (opt.bus) {
+					case '00':
+						return input == tally.busA
+					case '01':
+						return input == tally.busB
+					case '02':
+						return input == tally.pgm
+					case '03':
+						return input == tally.pvw
+					case '04':
+						return input == tally.keyF
+					case '05':
+						return input == tally.keyS
+					case '06':
+						return input == tally.dskF
+					case '07':
+						return input == tally.dskS
+					case '08':
+						return input == tally.dsk2F
+					case '09':
+						return input == tally.dsk2S
+					case '10':
+						return input == tally.pinP1
+					case '11':
+						return input == tally.pinP2
+					case '12':
+						return input == tally.aux1
+					case '13':
+						return input == tally.aux2
+					case '14':
+						return input == tally.aux3
+					case '15':
+						return input == tally.aux4
+					case '16':
+						return input == tally.aux1s
+					case '17':
+						return input == tally.pinP1s
+					case '18':
+						return input == tally.pinP2s
+					default:
+						return false
+				}
+			},
 		}
 
-		self.setFeedbackDefinitions(feedbacks);
-	}
+		self.setFeedbackDefinitions(feedbacks)
+	},
 }

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -103,6 +103,55 @@ module.exports = {
 			},
 		}
 
+		if (self.config.model == 'HS410' || self.config.model == 'HS450') {
+			feedbacks.auto_status = {
+				type: 'boolean',
+				name: 'Auto Transition Status',
+				description:
+					'True when an ATST target matches the selected auto-transition state (00=stop, 01=pause, 02=running)',
+				defaultStyle: {
+					color: combineRgb(255, 255, 255),
+					bgcolor: combineRgb(0, 180, 0),
+				},
+				options: [
+					{
+						label: 'Target',
+						type: 'dropdown',
+						id: 'target',
+						choices: self.ATST_TARGETS,
+						default: '0',
+					},
+					{
+						label: 'State',
+						type: 'dropdown',
+						id: 'state',
+						choices: self.ATST_STATES,
+						default: '02',
+					},
+				],
+				callback: function (feedback) {
+					const auto = self.data.tally.autoTrans || {}
+					const current = auto[feedback.options.target]
+					return current === feedback.options.state
+				},
+			}
+
+			feedbacks.auto_running = {
+				type: 'boolean',
+				name: 'Auto Transition Running',
+				description: 'True when any ATST target reports state 02 (transition running)',
+				defaultStyle: {
+					color: combineRgb(255, 255, 255),
+					bgcolor: combineRgb(255, 140, 0),
+				},
+				options: [],
+				callback: function () {
+					const auto = self.data.tally.autoTrans || {}
+					return Object.values(auto).some((code) => code === '02')
+				},
+			}
+		}
+
 		self.setFeedbackDefinitions(feedbacks)
 	},
 }

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -120,7 +120,7 @@ module.exports = {
 
 			feedbacks.atly_tally = {
 				type: 'boolean',
-				name: 'ATLY Input Tally (PGM/PVW)',
+				name: 'Input Tally Feedback (PGM/PVW-only)',
 				description:
 					'True when ATLY reports the selected physical input on PGM (red) or PVW (green). Bit0=Input 1 … — independent of XPT button mapping. Requires multicast.',
 				defaultStyle: {

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -117,6 +117,8 @@ module.exports = {
 
 		if (self.config.model == 'HS410' || self.config.model == 'HS450') {
 			const runningStates = self.ATST_RUNNING_STATES || ['02', '04', '06']
+			const atstTargets =
+				self[self.config.model + '_ATST_TARGETS'] || self.HS450_ATST_TARGETS
 
 			feedbacks.atly_tally = {
 				type: 'boolean',
@@ -169,7 +171,7 @@ module.exports = {
 						label: 'Target',
 						type: 'dropdown',
 						id: 'target',
-						choices: self.ATST_TARGETS,
+						choices: atstTargets,
 						default: '0',
 					},
 					{
@@ -217,7 +219,7 @@ module.exports = {
 						label: 'Target',
 						type: 'dropdown',
 						id: 'target',
-						choices: self.ATST_TARGETS,
+						choices: atstTargets,
 						default: '0',
 					},
 				],
@@ -241,7 +243,7 @@ module.exports = {
 						label: 'Target',
 						type: 'dropdown',
 						id: 'target',
-						choices: self.ATST_TARGETS,
+						choices: atstTargets,
 						default: '1',
 					},
 				],

--- a/src/feedbacks.js
+++ b/src/feedbacks.js
@@ -11,12 +11,18 @@ module.exports = {
 		let model = self.config.model
 		let buses = self[model + '_BUS'] || []
 		let inputs = self[model + '_INPUTS'] || []
+		// ABST reports the selected XPT button (00–31 / 99), not the physical
+		// input or internal source. Keep those out of the dropdown.
+		let xptChoices = inputs.filter((i) => /^XPT\s+\d+/i.test(i.label) || i.id === '99')
+		if (xptChoices.length === 0) {
+			xptChoices = inputs
+		}
 
 		feedbacks.tally = {
 			type: 'boolean',
 			name: 'Tally Feedback',
 			description:
-				'True when the selected XPT/source is currently selected on the bus. Requires multicast tally (HS410/HS450); on other models this stays off.',
+				'True when the selected XPT is currently selected on the bus (ABST crosspoint, not the physical input). Requires multicast tally (HS410/HS450); on other models this stays off.',
 			defaultStyle: {
 				color: foregroundColor,
 				bgcolor: backgroundColor,
@@ -30,11 +36,11 @@ module.exports = {
 					default: buses[0] ? buses[0].id : '02',
 				},
 				{
-					label: 'Input',
+					label: 'XPT',
 					type: 'dropdown',
 					id: 'input',
-					choices: inputs,
-					default: inputs[0] ? inputs[0].id : '00',
+					choices: xptChoices,
+					default: xptChoices[0] ? xptChoices[0].id : '00',
 				},
 			],
 			callback: function (feedback) {

--- a/src/presets.js
+++ b/src/presets.js
@@ -19,7 +19,7 @@ module.exports = {
 		let model = self.config.model
 		let buses = self[model + '_BUS'] || []
 		let inputs = self[model + '_INPUTS'] || []
-		let targets = self[model + '_TARGETS'] || []
+		let targets = self.getSautTargets()
 		let cutTargets = self[model + '_CUTTARGETS'] || self[model + '_TARGETS'] || []
 
 		const busStyle = {

--- a/src/presets.js
+++ b/src/presets.js
@@ -112,6 +112,29 @@ module.exports = {
 		}
 
 		for (let target of targets) {
+			// SAUT ids are zero-padded ("02"); ATST wire/target ids are not ("2").
+			const atstTarget = String(parseInt(target.id, 10))
+			const autoFeedbacks = []
+			if (self.config.model == 'HS410' || self.config.model == 'HS450') {
+				autoFeedbacks.push(
+					{
+						feedbackId: 'auto_target_on',
+						options: { target: atstTarget },
+						style: {
+							color: fgWhite,
+							bgcolor: tallyGreen,
+						},
+					},
+					{
+						feedbackId: 'auto_target_running',
+						options: { target: atstTarget },
+						style: {
+							color: fgWhite,
+							bgcolor: bgOrange,
+						},
+					}
+				)
+			}
 			presets[`auto_${target.id}`] = {
 				type: 'button',
 				category: 'Transitions',
@@ -135,7 +158,7 @@ module.exports = {
 						up: [],
 					},
 				],
-				feedbacks: [],
+				feedbacks: autoFeedbacks,
 			}
 		}
 

--- a/src/presets.js
+++ b/src/presets.js
@@ -2,15 +2,143 @@ const { combineRgb } = require('@companion-module/base')
 
 module.exports = {
 	initPresets: function () {
-		let self = this;
-		let presets = []
+		let self = this
+		let presets = {}
 
-		const foregroundColor = combineRgb(255, 255, 255) // White
-		const foregroundColorBlack = combineRgb(0, 0, 0) // Black
-		const backgroundColorRed = combineRgb(255, 0, 0) // Red
-		const backgroundColorGreen = combineRgb(0, 255, 0) // Green
-		const backgroundColorOrange = combineRgb(255, 102, 0) // Orange
+		const fgWhite = combineRgb(255, 255, 255)
+		const fgBlack = combineRgb(0, 0, 0)
+		const bgDark = combineRgb(30, 30, 30)
+		const bgOrange = combineRgb(200, 100, 0)
+		const tallyRed = combineRgb(255, 0, 0)
+		const tallyGreen = combineRgb(0, 180, 0)
+		const tallyBlue = combineRgb(0, 80, 180)
+		const dimRed = combineRgb(90, 0, 0)
+		const dimGreen = combineRgb(0, 70, 0)
+		const dimBlue = combineRgb(0, 35, 90)
 
-		self.setPresetDefinitions(presets);
-	}
-}	
+		let model = self.config.model
+		let buses = self[model + '_BUS'] || []
+		let inputs = self[model + '_INPUTS'] || []
+		let targets = self[model + '_TARGETS'] || []
+		let cutTargets = self[model + '_CUTTARGETS'] || self[model + '_TARGETS'] || []
+
+		const busStyle = {
+			'02': { category: 'PGM', short: 'PGM', idle: dimRed, tally: tallyRed },
+			'03': { category: 'PVW', short: 'PVW', idle: dimGreen, tally: tallyGreen },
+			'12': { category: 'AUX 1', short: 'AUX1', idle: dimBlue, tally: tallyBlue },
+			'13': { category: 'AUX 2', short: 'AUX2', idle: dimBlue, tally: tallyBlue },
+			'14': { category: 'AUX 3', short: 'AUX3', idle: dimBlue, tally: tallyBlue },
+			'15': { category: 'AUX 4', short: 'AUX4', idle: dimBlue, tally: tallyBlue },
+		}
+
+		let xptSources = inputs.filter((i) => /^XPT\s+\d+/i.test(i.label))
+		if (xptSources.length === 0) {
+			xptSources = inputs
+		}
+
+		for (let bus of buses) {
+			let style = busStyle[bus.id]
+			if (!style) continue
+
+			for (let src of xptSources) {
+				let shortSrc = src.label.replace(/^XPT\s+/i, '')
+				presets[`xpt_${bus.id}_${src.id}`] = {
+					type: 'button',
+					category: style.category,
+					name: `${src.label} → ${bus.label}`,
+					style: {
+						text: `${shortSrc}\\n${style.short}`,
+						size: '14',
+						color: fgWhite,
+						bgcolor: style.idle,
+					},
+					steps: [
+						{
+							down: [
+								{
+									actionId: 'xpt',
+									options: {
+										bus: bus.id,
+										input: src.id,
+									},
+								},
+							],
+							up: [],
+						},
+					],
+					feedbacks: [
+						{
+							feedbackId: 'tally',
+							options: {
+								bus: bus.id,
+								input: src.id,
+							},
+							style: {
+								color: fgWhite,
+								bgcolor: style.tally,
+							},
+						},
+					],
+				}
+			}
+		}
+
+		for (let target of cutTargets) {
+			presets[`cut_${target.id}`] = {
+				type: 'button',
+				category: 'Transitions',
+				name: `CUT ${target.label}`,
+				style: {
+					text: `CUT\\n${target.label}`,
+					size: '14',
+					color: fgBlack,
+					bgcolor: bgOrange,
+				},
+				steps: [
+					{
+						down: [
+							{
+								actionId: 'cut',
+								options: {
+									target: target.id,
+								},
+							},
+						],
+						up: [],
+					},
+				],
+				feedbacks: [],
+			}
+		}
+
+		for (let target of targets) {
+			presets[`auto_${target.id}`] = {
+				type: 'button',
+				category: 'Transitions',
+				name: `AUTO ${target.label}`,
+				style: {
+					text: `AUTO\\n${target.label}`,
+					size: '14',
+					color: fgWhite,
+					bgcolor: bgDark,
+				},
+				steps: [
+					{
+						down: [
+							{
+								actionId: 'auto',
+								options: {
+									target: target.id,
+								},
+							},
+						],
+						up: [],
+					},
+				],
+				feedbacks: [],
+			}
+		}
+
+		self.setPresetDefinitions(presets)
+	},
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -339,5 +339,25 @@ module.exports = {
 		for (let i = 0; i < str.length - 1; i++) {
 			self.interfaces.push(str[i])
 		}
-	}
+	},
+
+	// AUXP_IP Vol.2 SAUT is 2-field (SAUT:00:0). HS410 uses that when multicast
+	// is enabled (TCP 60020); otherwise HS410_IF 3-field SAUT on 60040.
+	usesAuxpIpSaut: function () {
+		let self = this
+		return (
+			self.config.model == 'HS50' ||
+			self.config.model == 'HS450' ||
+			(self.config.model == 'HS410' && self.config.multicast == true)
+		)
+	},
+
+	getSautTargets: function () {
+		let self = this
+		let model = self.config.model
+		if (model == 'HS410' && self.config.multicast == true) {
+			return self.HS410_AUXP_TARGETS
+		}
+		return self[model + '_TARGETS'] || []
+	},
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -121,6 +121,31 @@ module.exports = {
 		}
 	},
 
+	// Resolve an ABST source id against the model input table.
+	// HS450 (and sometimes HS410) omits leading zeros in multicast ABST
+	// frames — e.g. "5" instead of "05" — so match both the raw and a
+	// zero-padded (min 2 digit) form.
+	resolveInputLabel: function (rawId) {
+		let self = this;
+		let inputs = self[self.config.model + '_INPUTS'];
+		if (!inputs || rawId === undefined || rawId === null || rawId === '') {
+			return null;
+		}
+
+		let entry = inputs.find(({ id }) => id === rawId);
+		if (!entry) {
+			let padded = String(rawId).padStart(2, '0');
+			if (padded !== rawId) {
+				entry = inputs.find(({ id }) => id === padded);
+			}
+		}
+		if (!entry) {
+			self.log('debug', `Unknown ABST input id "${rawId}" for model ${self.config.model}`);
+			return String(rawId);
+		}
+		return entry.label;
+	},
+
 	// Store received data
 	storeData: function (str) {
 		let self = this;
@@ -128,63 +153,75 @@ module.exports = {
 
 		// Store Values from Events
 		switch (str[0]) {
-			case 'ABST':
+			case 'ABST': {
+				// ABST:<bus>:<source>[:<tally>]
+				let label = self.resolveInputLabel(str[2]);
+				if (label === null) {
+					break;
+				}
 				switch (str[1]) {
 					case '00':
-						tally.busA = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
+						tally.busA = label;
 						break // Bus A
 					case '01':
-						tally.busB = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
+						tally.busB = label;
 						break // Bus B
 					case '02':
-						tally.pgm = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
+						tally.pgm = label;
 						break // PGM
 					case '03':
-						tally.pvw = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
+						tally.pvw = label;
 						break // PVW
 					case '04':
-						tally.keyF = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
+						tally.keyF = label;
 						break // Key Fill
 					case '05':
-						tally.keyS = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
+						tally.keyS = label;
 						break // Key Source
 					case '06':
-						tally.dskF = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
-						break // DSK Fill
+						tally.dskF = label;
+						break // DSK1 Fill
 					case '07':
-						tally.dskS = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
-						break // DSK Source
+						tally.dskS = label;
+						break // DSK1 Source
+					case '08':
+						tally.dsk2F = label;
+						break // DSK2 Fill (HS450)
+					case '09':
+						tally.dsk2S = label;
+						break // DSK2 Source (HS450)
 					case '10':
-						tally.pinP1 = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
+						tally.pinP1 = label;
 						break // PinP 1
 					case '11':
-						tally.pinP2 = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
+						tally.pinP2 = label;
 						break // PinP 2
 					case '12':
-						tally.aux1 = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
+						tally.aux1 = label;
 						break // AUX 1
 					case '13':
-						tally.aux2 = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
+						tally.aux2 = label;
 						break // AUX 2
 					case '14':
-						tally.aux3 = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
+						tally.aux3 = label;
 						break // AUX 3
 					case '15':
-						tally.aux4 = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
+						tally.aux4 = label;
 						break // AUX 4
 					case '16':
-						tally.aux1s = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
+						tally.aux1s = label;
 						break // AUX1 source (HS450)
 					case '17':
-						tally.pinP1s = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
+						tally.pinP1s = label;
 						break // PinP1 source (HS450)
 					case '18':
-						tally.pinP2s = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
+						tally.pinP2s = label;
 						break // PinP2 source (HS450)
 					default:
 						break
 				}
 				break
+			}
 			case 'ATST':
 				break // Store some data when ATST command is recieved
 			case 'SPAT':
@@ -267,9 +304,8 @@ module.exports = {
 					try {
 						self.multi.addMembership(multicastAddress, multicastInterface[i])
 					} catch (error) {
-						// catch errors, as there wil probably be at least some on one or more of your interfaces!
-						self.log('debug', "Multicast Error: Take a look to make sure tally isn't working.");
-						self.debug('debug', error);
+						// Expected on some interfaces; tally still works if one join succeeds.
+						self.log('debug', `Multicast join skipped on ${multicastInterface[i]}: ${error}`)
 					}
 				}
 			})
@@ -280,6 +316,8 @@ module.exports = {
 	// Get All Network Interfaces
 	getNetworkInterfaces: async function () {
 		let self = this
+
+		self.interfaces = []
 
 		let temp = await self.parseVariablesInString('$(internal:all_ip)');
 		let str = temp.split('\\n') // Split interfaces up

--- a/src/utils.js
+++ b/src/utils.js
@@ -24,7 +24,10 @@ module.exports = {
 			if (self.config.host) {
 				let portTCP = 60020;
 
-				if (self.config.model == 'HS410') {
+				if (self.config.model == 'HS450') {
+					portTCP = 60020;
+				}
+				else if (self.config.model == 'HS410') {
 					if (self.config.multicast == true) {
 						portTCP = 60020;
 					}
@@ -48,32 +51,32 @@ module.exports = {
 				});
 		
 				self.socket.on('connect', function () {
-					self.updateStatus(InstanceStatus.Ok);
-	
-					if (self.config.model == 'UHS500') {
-						self.timer = setInterval(function () {
-							self.sendCommand('SPAT:0:00')
-						}, 10000) // 10 sec keepalive command
-					}
-			
-					if (self.config.model == 'HS410') {
-						self.timer = setInterval(function () {
-							self.sendCommand('SPAT:0:00')
-						}, 500) // 500 ms keepalive command
-			
-						//console.log(self.config.multicast)
-						if (self.config.multicast == true) { // only when multicast is enabled in the config
-							try {
-								self.listenMulticast()
-								self.log('info', 'Multicast Tally is enabled')
-							} catch (e) {
-								console.log('Error listening for Multicast Tally', e)
-							}
-						} else { // If not, delete old multicast sockets
-							if (self.multi !== undefined) {
-								self.multi.destroy() // Somehow this is needed even though it's not defined, if you remove it, then Companion will crash when updating the instance, but if you leave it it works and you will only get an error thrown, LOL 🤷
-								delete self.multi
-							}			
+				self.updateStatus(InstanceStatus.Ok);
+
+				if (self.config.model == 'UHS500') {
+					self.timer = setInterval(function () {
+						self.sendCommand('SPAT:0:00')
+					}, 10000) // 10 sec keepalive command
+				}
+
+				if (self.config.model == 'HS450' || self.config.model == 'HS410') {
+					self.timer = setInterval(function () {
+						self.sendCommand('SPAT:0:00')
+					}, 500) // 500 ms keepalive command
+
+					//console.log(self.config.multicast)
+					if (self.config.multicast == true) { // only when multicast is enabled in the config
+						try {
+							self.listenMulticast()
+							self.log('info', 'Multicast Tally is enabled')
+						} catch (e) {
+							console.log('Error listening for Multicast Tally', e)
+						}
+					} else { // If not, delete old multicast sockets
+						if (self.multi !== undefined) {
+							self.multi.destroy() // Somehow this is needed even though it's not defined, if you remove it, then Companion will crash when updating the instance, but if you leave it it works and you will only get an error thrown, LOL 🤷
+							delete self.multi
+						}
 						}
 					}
 				});
@@ -128,47 +131,56 @@ module.exports = {
 			case 'ABST':
 				switch (str[1]) {
 					case '00':
-						tally.busA = self.HS410_INPUTS.find(({ id }) => id === str[2]).label
+						tally.busA = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
 						break // Bus A
 					case '01':
-						tally.busB = self.HS410_INPUTS.find(({ id }) => id === str[2]).label
+						tally.busB = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
 						break // Bus B
 					case '02':
-						tally.pgm = self.HS410_INPUTS.find(({ id }) => id === str[2]).label
+						tally.pgm = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
 						break // PGM
 					case '03':
-						tally.pvw = self.HS410_INPUTS.find(({ id }) => id === str[2]).label
+						tally.pvw = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
 						break // PVW
 					case '04':
-						tally.keyF = self.HS410_INPUTS.find(({ id }) => id === str[2]).label
+						tally.keyF = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
 						break // Key Fill
 					case '05':
-						tally.keyS = self.HS410_INPUTS.find(({ id }) => id === str[2]).label
+						tally.keyS = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
 						break // Key Source
 					case '06':
-						tally.dskF = self.HS410_INPUTS.find(({ id }) => id === str[2]).label
+						tally.dskF = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
 						break // DSK Fill
 					case '07':
-						tally.dskS = self.HS410_INPUTS.find(({ id }) => id === str[2]).label
+						tally.dskS = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
 						break // DSK Source
 					case '10':
-						tally.pinP1 = self.HS410_INPUTS.find(({ id }) => id === str[2]).label
+						tally.pinP1 = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
 						break // PinP 1
 					case '11':
-						tally.pinP2 = self.HS410_INPUTS.find(({ id }) => id === str[2]).label
+						tally.pinP2 = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
 						break // PinP 2
 					case '12':
-						tally.aux1 = self.HS410_INPUTS.find(({ id }) => id === str[2]).label
+						tally.aux1 = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
 						break // AUX 1
 					case '13':
-						tally.aux2 = self.HS410_INPUTS.find(({ id }) => id === str[2]).label
+						tally.aux2 = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
 						break // AUX 2
 					case '14':
-						tally.aux3 = self.HS410_INPUTS.find(({ id }) => id === str[2]).label
+						tally.aux3 = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
 						break // AUX 3
 					case '15':
-						tally.aux4 = self.HS410_INPUTS.find(({ id }) => id === str[2]).label
+						tally.aux4 = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
 						break // AUX 4
+					case '16':
+						tally.aux1s = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
+						break // AUX1 source (HS450)
+					case '17':
+						tally.pinP1s = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
+						break // PinP1 source (HS450)
+					case '18':
+						tally.pinP2s = self[self.config.model + '_INPUTS'].find(({ id }) => id === str[2]).label
+						break // PinP2 source (HS450)
 					default:
 						break
 				}

--- a/src/utils.js
+++ b/src/utils.js
@@ -223,7 +223,10 @@ module.exports = {
 				break
 			}
 			case 'ATST':
-				break // Store some data when ATST command is recieved
+				if (str.length >= 3) {
+					tally.autoTrans[str[1]] = str[2]
+				}
+				break
 			case 'SPAT':
 				break // Store some data when SPAT command is recieved
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -227,6 +227,17 @@ module.exports = {
 					tally.autoTrans[str[1]] = str[2]
 				}
 				break
+			case 'ATLY':
+				// ATLY:<pvw_hex>:<pgm_hex> — physical IN tally bitmasks.
+				// bit0 = Input 1 (source 50), bit1 = Input 2, … (confirmed live for PGM;
+				// PVW field matches earlier HS450 captures / AUXP_IP layout).
+				if (str.length >= 3) {
+					const pvw = parseInt(str[1], 16)
+					const pgm = parseInt(str[2], 16)
+					tally.atlyPvw = Number.isFinite(pvw) ? pvw >>> 0 : 0
+					tally.atlyPgm = Number.isFinite(pgm) ? pgm >>> 0 : 0
+				}
+				break
 			case 'SPAT':
 				break // Store some data when SPAT command is recieved
 

--- a/src/variables.js
+++ b/src/variables.js
@@ -9,8 +9,10 @@ module.exports = {
 		variables.push({ variableId: 'bus_b', name: 'Bus B Selected' })
 		variables.push({ variableId: 'key_fill', name: 'Key Fill Selected' })
 		variables.push({ variableId: 'key_source', name: 'Key Source Selected' })
-		variables.push({ variableId: 'dsk_fill', name: 'DSK Fill Selected' })
-		variables.push({ variableId: 'dsk_source', name: 'DSK Source Selected' })
+		variables.push({ variableId: 'dsk_fill', name: 'DSK1 Fill Selected' })
+		variables.push({ variableId: 'dsk_source', name: 'DSK1 Source Selected' })
+		variables.push({ variableId: 'dsk2_fill', name: 'DSK2 Fill Selected' })
+		variables.push({ variableId: 'dsk2_source', name: 'DSK2 Source Selected' })
 		variables.push({ variableId: 'pinp_1', name: 'PinP 1 Selected' })
 		variables.push({ variableId: 'pinp_2', name: 'PinP 2 Selected' })
 		variables.push({ variableId: 'aux_1', name: 'AUX 1 Selected' })
@@ -35,13 +37,15 @@ module.exports = {
 		variableObj['key_source'] = self.data.tally.keyS;
 		variableObj['dsk_fill'] = self.data.tally.dskF;
 		variableObj['dsk_source'] = self.data.tally.dskS;
+		variableObj['dsk2_fill'] = self.data.tally.dsk2F;
+		variableObj['dsk2_source'] = self.data.tally.dsk2S;
 		variableObj['pinp_1'] = self.data.tally.pinP1;
 		variableObj['pinp_2'] = self.data.tally.pinP2;
 		variableObj['aux_1'] = self.data.tally.aux1;
 		variableObj['aux_2'] = self.data.tally.aux2;
 		variableObj['aux_3'] = self.data.tally.aux3;
 		variableObj['aux_4'] = self.data.tally.aux4;
-		
+
 		self.setVariableValues(variableObj);
 	}
 }

--- a/src/variables.js
+++ b/src/variables.js
@@ -20,6 +20,13 @@ module.exports = {
 		variables.push({ variableId: 'aux_3', name: 'AUX 3 Selected' })
 		variables.push({ variableId: 'aux_4', name: 'AUX 4 Selected' })
 
+		if (self.config.model == 'HS410' || self.config.model == 'HS450') {
+			variables.push({ variableId: 'auto_bkgd', name: 'Auto Status: BKGD' })
+			variables.push({ variableId: 'auto_key', name: 'Auto Status: KEY' })
+			variables.push({ variableId: 'auto_aux', name: 'Auto Status: AUX' })
+			variables.push({ variableId: 'auto_any_running', name: 'Any Auto Transition Running' })
+		}
+
 		self.setVariableDefinitions(variables);
 	},
 
@@ -45,6 +52,20 @@ module.exports = {
 		variableObj['aux_2'] = self.data.tally.aux2;
 		variableObj['aux_3'] = self.data.tally.aux3;
 		variableObj['aux_4'] = self.data.tally.aux4;
+
+		if (self.config.model == 'HS410' || self.config.model == 'HS450') {
+			const auto = self.data.tally.autoTrans || {}
+			const label = (id) => {
+				const code = auto[id]
+				if (!code) return ''
+				const state = self.ATST_STATES.find(({ id }) => id === code)
+				return state ? state.label : code
+			}
+			variableObj['auto_bkgd'] = label('0')
+			variableObj['auto_key'] = label('1')
+			variableObj['auto_aux'] = label('7')
+			variableObj['auto_any_running'] = Object.values(auto).some((code) => code === '02') ? 'yes' : 'no'
+		}
 
 		self.setVariableValues(variableObj);
 	}

--- a/src/variables.js
+++ b/src/variables.js
@@ -23,6 +23,11 @@ module.exports = {
 		if (self.config.model == 'HS410' || self.config.model == 'HS450') {
 			variables.push({ variableId: 'auto_bkgd', name: 'Auto Status: BKGD' })
 			variables.push({ variableId: 'auto_key', name: 'Auto Status: KEY' })
+			variables.push({ variableId: 'auto_dsk1', name: 'Auto Status: DSK 1' })
+			variables.push({ variableId: 'auto_dsk2', name: 'Auto Status: DSK 2' })
+			variables.push({ variableId: 'auto_pinp1', name: 'Auto Status: PinP 1' })
+			variables.push({ variableId: 'auto_pinp2', name: 'Auto Status: PinP 2' })
+			variables.push({ variableId: 'auto_ftb', name: 'Auto Status: FTB' })
 			variables.push({ variableId: 'auto_aux', name: 'Auto Status: AUX' })
 			variables.push({ variableId: 'auto_any_running', name: 'Any Auto Transition Running' })
 		}
@@ -55,16 +60,26 @@ module.exports = {
 
 		if (self.config.model == 'HS410' || self.config.model == 'HS450') {
 			const auto = self.data.tally.autoTrans || {}
+			const runningStates = self.ATST_RUNNING_STATES || ['02', '04', '06']
 			const label = (id) => {
 				const code = auto[id]
 				if (!code) return ''
-				const state = self.ATST_STATES.find(({ id }) => id === code)
+				const state = self.ATST_STATES.find(({ id: sid }) => sid === code)
 				return state ? state.label : code
 			}
 			variableObj['auto_bkgd'] = label('0')
 			variableObj['auto_key'] = label('1')
+			variableObj['auto_dsk1'] = label('2')
+			variableObj['auto_dsk2'] = label('3')
+			variableObj['auto_pinp1'] = label('4')
+			variableObj['auto_pinp2'] = label('5')
+			variableObj['auto_ftb'] = label('6')
 			variableObj['auto_aux'] = label('7')
-			variableObj['auto_any_running'] = Object.values(auto).some((code) => code === '02') ? 'yes' : 'no'
+			variableObj['auto_any_running'] = Object.values(auto).some((code) =>
+				runningStates.includes(code)
+			)
+				? 'yes'
+				: 'no'
 		}
 
 		self.setVariableValues(variableObj);


### PR DESCRIPTION
## Summary
- Adds **AV-HS450** as a first-class model in this module, using the existing AUXP_IP / HS410 path (TCP **60020**, multicast tally **224.0.0.200:60020**) rather than a new protocol stack.
- Verified against a live AV-HS450: 32 XPTs, 20 physical inputs, dual DSK, unpadded ABST source IDs, XPT presets with tally feedback, ATST auto status, ATLY input tally.
- HS410 with **multicast on** now uses official AUXP_IP two-field `SAUT` (DSK=`02`, PinP=`04`/`05`) so DSK/PinP AUTO keep working with tally enabled.
- Also addresses upstream [#7](https://github.com/bitfocus/companion-module-panasonic-avhs/issues/7) (DSK toggle via AUTO + ATST on/off on HS450) and [#14](https://github.com/bitfocus/companion-module-panasonic-avhs/issues/14) (PinP broken after enabling tally).
- upstream metadata/readme formatting cleanup from [#25](https://github.com/bitfocus/companion-module-panasonic-avhs/pull/25).

## Credits
This sits on the existing Bitfocus module by **Håkon Nessjøen**, **Andreas H. Thomsen**, and **Joseph Adams** (connection handling, `SBUS` / `SAUT` / `SCUT` / `STIM`, keepalive, multicast tally, Companion v3 layout).

Panasonic **AUXP_IP** (AV-HS410 Vol.2) and the Venetex **VS-R45** panel behaviour confirmed STX/ETX framing, multicast status (not TCP ACK), and DSK1+DSK2 on the panel.

**Related work:** [Sotiri Wiersma](https://github.com/sotiriwiersma) added AV-HS450 (plus AV-HS6000 and AV-HSW10) in [#24](https://github.com/bitfocus/companion-module-panasonic-avhs/pull/24) / [their fork](https://github.com/sotiriwiersma/companion-module-panasonic-avhs). That work was **not** merged into this branch; HS450 was implemented separately against a live mixer. HS6000/HSW10 remain in Sotiri’s PR and are out of scope here (since there are already separate plugins for those).

## HS450 specifics (vs treating it as an HS410)
- TCP port is **always 60020** (60040 is closed on the unit we tested). Sotiri’s PR used HS410-style 60040 unless multicast is on.
- Source table: XPT `00`–`31`, inputs `50`–`69`, HS450 names (`FMEM1–4`, `MV1`/`MV2`).
- **DSK2:** buses `08`/`09` (Fill/Source). AUTO targets **`02` = DSK1, `03` = DSK2** (AUXP_IP; the stock `07` id is HS410_IF-only and is ignored here).
- ABST source IDs may be unpadded (`5` vs `05`); lookup no longer crashes on `.label`.

## Non-HS450-specific changes
- Added XPT presets for PGM / PVW / AUX1–4 (dim idle colour, bright tally).
- **CUT** presets are limited to BKGD and KEY; **AUTO** includes both DSKs (with ATST on/running feedbacks where the mixer reports them).
- HS410 + multicast: AUXP_IP SAUT shape/targets (fixes PinP/DSK AUTO with tally on).
- Tally feedback only works on multicast-enabled models (out of the box on an HS450, on HS410 with the proper plugin).
- Synced the module manifest `products` field to a proper JSON array and fixed the README links to `companion/HELP.md` and `LICENSE`, matching upstream [#25](https://github.com/bitfocus/companion-module-panasonic-avhs/pull/25).

## Known protocol limits (confirmed live / AUXP_IP Vol.2)
- **SCUT** only works for BKGD and KEY on AUXP_IP. DSK / PinP / FTB have AUTO only.
- **STIM** (auto transition time) is HS410_IF-only. Not offered for HS450 and HS50.
- HS410 AUXP_IP **ATST** does not publish DSK status (slots 2–6 unused); DSK on/off feedback via ATST is HS450-oriented.

## Test plan
- [ ] HS450: AUTO DSK1/DSK2 toggles; button shows on (`05`) / transitioning (`04`/`06`)
- [ ] HS410 multicast on: PinP1/PinP2 AUTO works (regression for #14)
- [ ] HS410 multicast on: DSK AUTO via `SAUT:02:0`
- [ ] HS410 multicast off: existing HS410_IF 3-field SAUT / DSK=`07` still works
- [ ] XPT + tally feedback unchanged

## AI disclaimer
- The rewrite and code review was done using AI-assisted programming tools. All tests were done manually by me on a physical HS450.